### PR TITLE
small addition to the 'show_top_losses'

### DIFF
--- a/fastai/text/interpret.py
+++ b/fastai/text/interpret.py
@@ -74,7 +74,7 @@ class TextClassificationInterpretation(ClassificationInterpretation):
         text, attn = self.intrinsic_attention(text, class_id)
         show_piece_attn(text.text.split(), to_np(attn), **kwargs)
 
-    def show_top_losses(self, k:int, max_len:int=70)->None:
+    def show_top_losses(self, k:int, max_len:int=70, return_df:bool):
         """
         Create a tabulation showing the first `k` texts in top_losses along with their prediction, actual,loss, and probability of
         actual class. `max_len` is the maximum number of tokens displayed.
@@ -97,3 +97,6 @@ class TextClassificationInterpretation(ClassificationInterpretation):
         df = pd.DataFrame({n:items[:,i] for i,n in enumerate(names)}, columns=names)
         with pd.option_context('display.max_colwidth', -1):
             display(HTML(df.to_html(index=False)))
+            
+        if return_df:
+            return df


### PR DESCRIPTION
allow to return the "top losses" as a data frame for error analysis

 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [ ] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [ ] If you are adding new functionality, create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality.
 - [ ] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!
 - [ ] Add details about your PR.
