### PR TITLE
Update the default "ordered" for "get_preds"

### DIFF
--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -83,7 +83,7 @@ class RNNLearner(Learner):
         return self
 
     def get_preds(self, ds_type:DatasetType=DatasetType.Valid, activ:nn.Module=None, with_loss:bool=False, n_batch:Optional[int]=None,
-                  pbar:Optional[PBar]=None, ordered:bool=False) -> List[Tensor]:
+                  pbar:Optional[PBar]=None, ordered:bool=True) -> List[Tensor]:
         "Return predictions and targets on the valid, train, or test set, depending on `ds_type`."
         self.model.reset()
         if ordered: np.random.seed(42)


### PR DESCRIPTION
It makes more sense to set the "ordered" default "True" to get the results from the validation/test set.

The issue was discussed in 
https://forums.fast.ai/t/does-get-preds-randomize-shuffle-the-order-of-the-predictions/44329/2

